### PR TITLE
Add signout and testing token

### DIFF
--- a/controllers/accessGroupController.js
+++ b/controllers/accessGroupController.js
@@ -1,6 +1,5 @@
 const logger = require('../utils/logger');
 logger.debug('>>> accessGroupController loaded');
-console.log('>>> FILEN LASTER INN');
 const jwt = require('jsonwebtoken');
 
 const db = require('../config/db');
@@ -185,7 +184,6 @@ exports.getAccessGroupDetails = async (req, res) => {
      [groupId]
    );
 members = Array.isArray(members) && Array.isArray(members[0]) ? members[0] : members;
-    members = Array.isArray(members) && Array.isArray(members[0]) ? members[0] : members;
 
     // Hent låser
     let [locks] = await db.query(

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 const logger = require('../utils/logger');
+const tokenStore = require('../utils/tokenStore');
 
 function verifyToken(req, res, next) {
   logger.debug('[DEBUG] Header:', req.headers.authorization);
@@ -26,6 +27,10 @@ function verifyToken(req, res, next) {
   }
 
   try {
+    if (tokenStore.isRevoked(token)) {
+      console.warn('[AUTH] Token er tilbakekalt');
+      return res.status(401).json({ error: 'Ugyldig token' });
+    }
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded;
     logger.info('[AUTH] Token verifisert for bruker', decoded.id);

--- a/routes/accessGroupRoutes.js
+++ b/routes/accessGroupRoutes.js
@@ -3,11 +3,6 @@ const router = express.Router();
 const { verifyToken, requireAdmin } = require('../middleware/authMiddleware');
 const accessGroupController = require('../controllers/accessGroupController');
 const logger = require('../utils/logger');
-logger.debug('TYPE OF requireAdmin:', typeof requireAdmin);
-logger.debug('controller:', accessGroupController);
-logger.debug('createGroup:', accessGroupController.createGroup);
-logger.debug('verifyToken:', typeof verifyToken);
-logger.debug('requireAdmin:', typeof requireAdmin);
 /**
  * @swagger
  * /accessGroup/list:
@@ -52,17 +47,102 @@ logger.debug('requireAdmin:', typeof requireAdmin);
  */
 router.post('/list', verifyToken, accessGroupController.getAccessGroupsForUser);
 
+/**
+ * 
+ * /accessgroup/create:
+ *   post:
+ *     summary: Opprett ny tilgangsgruppe
+ *     tags:
+ *       - Tilgangsgrupper
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Resultat av opprettelse
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 groupId:
+ *                   type: integer
+ *       500:
+ *         description: Kunne ikke opprette gruppe
+ */
 // Opprett ny tilgangsgruppe
 router.post('/create', verifyToken, accessGroupController.createGroup);
 
+/**
+ * 
+ * /accessgroup/add-user:
+ *   post:
+ *     summary: Legg til bruker i gruppe
+ *     tags:
+ *       - Tilgangsgrupper
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               groupId:
+ *                 type: integer
+ *               userId:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Bruker lagt til
+ *       500:
+ *         description: Kunne ikke legge til bruker
+ */
 // Legg til bruker i gruppe
 router.post('/add-user', verifyToken, accessGroupController.addUserToGroup);
 
+/**
+ * 
+ * /accessgroup/add-lock:
+ *   post:
+ *     summary: Legg til lås i gruppe
+ *     tags:
+ *       - Tilgangsgrupper
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               groupId:
+ *                 type: integer
+ *               lockId:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Lås lagt til
+ *       500:
+ *         description: Kunne ikke legge til lås
+ */
 // Legg til lås i gruppe
 router.post('/add-lock', verifyToken, accessGroupController.addLockToGroup);
 /**
  * @swagger
- * /accessgroup/users:
+ * /users:
  *   post:
  *     summary: Hent brukere i en tilgangsgruppe
  *     tags:
@@ -102,8 +182,31 @@ router.post('/add-lock', verifyToken, accessGroupController.addLockToGroup);
  *       500:
  *         description: Serverfeil
  */
-router.post('/accessgroup/users', accessGroupController.getUsersInAccessGroup);
+router.post('/users', verifyToken, accessGroupController.getUsersInAccessGroup);
 
+/**
+ * @swagger
+ * /accessgroup/{groupId}/details:
+ *   get:
+ *     summary: Hent detaljer for en tilgangsgruppe
+ *     tags:
+ *       - Tilgangsgrupper
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: groupId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Gruppens detaljer
+ *       404:
+ *         description: Adgangsgruppe ikke funnet
+ *       500:
+ *         description: Serverfeil
+ */
 router.get('/:groupId/details', verifyToken, accessGroupController.getAccessGroupDetails);
 
 

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -71,7 +71,7 @@ router.post('/login', userController.loginUser);
  *       400:
  *         description: Mangler nødvendig data
  */
-router.post('/userlocks/shared-users', userlocksController.getSharedUsers);
+router.post('/userlocks/shared-users', verifyToken, userlocksController.getSharedUsers);
 /**
  * @swagger
 *   /user/details/{userId}:
@@ -124,8 +124,92 @@ router.post('/userlocks/shared-users', userlocksController.getSharedUsers);
 */
 router.get('/details/:userId', verifyToken, userController.getUserAccessDetails);
 
+/**
+ * @swagger
+ * /user/register:
+ *   post:
+ *     summary: Registrer ny bruker
+ *     tags:
+ *       - Autentisering
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *               phone_number:
+ *                 type: string
+ *               first_name:
+ *                 type: string
+ *               last_name:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Bruker registrert
+ *       409:
+ *         description: E-posten er allerede i bruk
+ *       400:
+ *         description: Manglende informasjon
+ *       500:
+ *         description: Serverfeil under registrering
+ */
 router.post('/register', userController.registerUser);
 
+/**
+ * @swagger
+ * /user/isadmin:
+ *   get:
+ *     summary: Sjekk om innlogget bruker er admin
+ *     tags:
+ *       - Bruker
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Om brukeren er admin
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isAdmin:
+ *                   type: boolean
+ *       500:
+ *         description: Serverfeil under admin-sjekk
+ */
 router.get('/isadmin', verifyToken, userController.checkIfAdmin);
+
+/**
+ * @swagger
+ * /user/signout:
+ *   post:
+ *     summary: Logg ut og ugyldiggjør gjeldende token
+ *     tags:
+ *       - Autentisering
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Token slettet
+ */
+router.post('/signout', verifyToken, userController.signOut);
+
+/**
+ * @swagger
+ * /user/test-token:
+ *   get:
+ *     summary: Hent et testtoken
+ *     tags:
+ *       - Autentisering
+ *     responses:
+ *       200:
+ *         description: Returnerer et JWT for testing
+ */
+router.get('/test-token', userController.getTestToken);
 
 module.exports = router;

--- a/utils/tokenStore.js
+++ b/utils/tokenStore.js
@@ -1,0 +1,9 @@
+const revoked = new Set();
+module.exports = {
+  revoke(token) {
+    if (token) revoked.add(token);
+  },
+  isRevoked(token) {
+    return revoked.has(token);
+  }
+};


### PR DESCRIPTION
## Summary
- verify tokens against a revoked token store
- return generic login errors and handle array results
- enforce auth on user-related routes
- add `/user/signout` and `/user/test-token` endpoints
- include simple token store for revoked tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683c2b462aac832289356635888f6a3b